### PR TITLE
Fix mini-job salary text

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
                         </div>
                         <div class="option-card" id="minijob-option">
                             <h3>Ich bin ein Mini-Jobber!</h3>
-                            <p>Regelmäßige Teilzeit, bis 538€ monatlich</p>
+                            <p>Regelmäßige Teilzeit, bis 556€ monatlich</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- update the mini-jobber info text to show the correct limit of 556€ per month

## Testing
- `grep -n 556 -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_6875f4ce5f7883328e33aa1bdfeea387