### PR TITLE
Fix API URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Fair Taste Berlin
+
+This repo contains a simple form for submitting job applications and a small Node server that relays submissions via email.
+
+## Running locally
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Create an `.env` file based on `.env.example` and provide the SMTP credentials.
+3. Start the server:
+   ```bash
+   npm start
+   ```
+   The server will listen on port `3000` by default.
+
+## Deploying static site
+
+When hosting the front‑end on a different domain (for example GitHub Pages) you need to specify the URL of your backend API. Edit the `window.API_BASE_URL` value in `index.html` or set it dynamically before `app.js` is loaded:
+
+```html
+<script>
+  window.API_BASE_URL = "https://your-backend.example.com";
+</script>
+<script src="app.js"></script>
+```
+
+The form will post to `<API_BASE_URL>/api/apply`.

--- a/app.js
+++ b/app.js
@@ -246,7 +246,8 @@ function handleFormSubmissionWithLoading(event) {
     formData.append('subject', emailData.subject);
     formData.append('body', emailData.body);
 
-    fetch('/api/apply', {
+    const base = window.API_BASE_URL ? window.API_BASE_URL.replace(/\/?$/, '') : '';
+    fetch(`${base}/api/apply`, {
         method: 'POST',
         body: formData
     })

--- a/index.html
+++ b/index.html
@@ -133,6 +133,11 @@
         </footer>
     </div>
 
+    <script>
+        // Set API_BASE_URL to the URL where the Node server is hosted.
+        // Leave empty when the frontend and backend run on the same origin.
+        window.API_BASE_URL = '';
+    </script>
     <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow the API base URL to be set via `window.API_BASE_URL`
- add an example script tag in the HTML
- document how to run locally and configure the API URL

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877d19dbb48833280000964853fd293