### PR TITLE
Serve frontend from Express

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ This repo contains a simple form for submitting job applications and a small Nod
    ```bash
    npm start
    ```
-   The server will listen on port `3000` by default.
+   The server will listen on port `3000` by default and serves the form from the same origin.
+   Open [http://localhost:3000](http://localhost:3000) to access the form and API.
 
 ## Deploying static site
 
-When hosting the front‑end on a different domain (for example GitHub Pages) you need to specify the URL of your backend API. Edit the `window.API_BASE_URL` value in `index.html` or set it dynamically before `app.js` is loaded:
+The easiest way to run the project is to use the Node server which serves both the form and the API.
+When hosting the front‑end on a different domain (for example GitHub Pages) you still need to specify the URL of your backend API. Edit the `window.API_BASE_URL` value in `index.html` or set it dynamically before `app.js` is loaded:
 
 ```html
 <script>

--- a/server.js
+++ b/server.js
@@ -2,11 +2,13 @@ const express = require('express');
 const cors = require('cors');
 const multer = require('multer');
 const nodemailer = require('nodemailer');
+const path = require('path');
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 const app = express();
 app.use(cors());
+app.use(express.static(path.join(__dirname)));
 
 // Load SMTP configuration from environment variables
 const {


### PR DESCRIPTION
## Summary
- host static files from Express so the form and API share the same origin
- document running with `npm start` and external hosting options

## Testing
- `npm install`
- `npm start` (manually killed)
- `curl -I http://localhost:3000`

------
https://chatgpt.com/codex/tasks/task_e_6877d87224708332b5b5a250ebc8fcd2