### PR TITLE
Fix email fallback handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This repo contains a simple form for submitting job applications and a small Nod
    npm install
    ```
 2. Create an `.env` file based on `.env.example` and provide the SMTP credentials.
+   When no credentials are provided, the server automatically falls back to a temporary
+   [Ethereal](https://ethereal.email/) account and prints a preview URL for each email.
 3. Start the server:
    ```bash
    npm start


### PR DESCRIPTION
## Summary
- add automatic Ethereal fallback when SMTP config is missing
- document the new fallback in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877db23a2088332a05e9fdf527b88c5